### PR TITLE
Update CI and PR Labeler workflows for 'develop' branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop]
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 jobs:
   build:

--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -3,7 +3,7 @@ name: PR Labeler
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    branches: [main]
+    branches: [main, develop]
 
 jobs:
   labeler:


### PR DESCRIPTION
Update branch references in CI and PR Labeler workflows to include 'develop' alongside 'main'. This change ensures that both branches are considered during CI processes and pull request labeling.

