### PR TITLE
Update Git PR Release workflow to trigger on closed pull requests

### DIFF
--- a/.github/workflows/git-pr-release.yaml
+++ b/.github/workflows/git-pr-release.yaml
@@ -1,13 +1,15 @@
 name: Git PR Release
 
 on:
-  push:
+  pull_request:
+    types: [closed]
     branches:
       - develop
 
 jobs:
   create-release-pr:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Summary

Update the Git PR Release workflow to trigger when pull requests are closed and only create a release if the pull request was merged.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe)

## Related Issue

<!-- Link to related issue: Fixes #123 -->

## Changes Made

- Changed the trigger from push to pull_request for closed events.
- Added a condition to check if the pull request was merged before creating a release.

## Testing

- [ ] Tested locally with `npm run dev`
- [ ] Tested with Docker
- [ ] Added/updated tests

## Checklist

- [ ] Code follows the project's coding style
- [ ] Self-reviewed the code
- [ ] Ran `npm run lint` with no errors
- [ ] Ran `npm run build` successfully
- [ ] Updated documentation if needed

## Screenshots

<!-- If applicable, add screenshots -->

