### PR TITLE
fix: update CI workflow to trigger only on push to main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main]
   pull_request:
     branches: [main, develop]
 

--- a/.github/workflows/git-pr-release.yaml
+++ b/.github/workflows/git-pr-release.yaml
@@ -6,6 +6,9 @@ on:
 jobs:
   git-pr-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
fix: add permissions for git-pr-release workflow

## Summary

<!-- Brief description of the changes -->

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other (please describe)

## Related Issue

<!-- Link to related issue: Fixes #123 -->

## Changes Made

<!-- List the main changes -->

-
-
-

## Testing

<!-- How did you test these changes? -->

- [ ] Tested locally with `npm run dev`
- [ ] Tested with Docker
- [ ] Added/updated tests

## Checklist

- [ ] Code follows the project's coding style
- [ ] Self-reviewed the code
- [ ] Ran `npm run lint` with no errors
- [ ] Ran `npm run build` successfully
- [ ] Updated documentation if needed

## Screenshots

<!-- If applicable, add screenshots -->
